### PR TITLE
FIX: makefile issues with 1.14 and latest pi zero firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,26 @@ Clone this repo and move the files to the relevant paths on the Raspiberry Pi Ze
     # Clone the repo onto the Pi Zero
     (rpi) $ cd ~
     (rpi) $ git clone https://github.com/tensorflow/tensorflow.git
+    (rpi) $ git checkout v1.14.0
     (rpi) $ cd ./tensorflow
+    or download it directly from https://github.com/tensorflow/tensorflow/releases/tag/v1.14.0
 
     # Install the dependencies
     (rpi) $ ./tensorflow/lite/tools/make/download_dependencies.sh
 
 # FTP/scp the arm6 build script to /home/pi/tensorflow/tensorflow/lite/tools/make
-(host)$ scp <local_path_to>/build_rpi_armv6_lib.sh pi@192.168.0.1:<rpi_path_to>/tensorflow/tensorflow/lite/tools/make
+(host)$ scp <local_path_to>/build_rpi_armv6_lib.sh pi@[pi's ip]:<rpi_path_to>/tensorflow/tensorflow/lite/tools/make
 
 # FTP/scp the updated Makefile that builds the label_image example as well
 (rpi) $ cd <path_to>/tensorflow/tensorflow/lite/tools/make
 (rpi) $ mv Makefile Makefile.orig
-(host)$ scp <local_path_to>/Makefile pi@192.168.0.1:<rpi_path_to>/tensorflow/tensorflow/lite/tools/make
+(host)$ scp <local_path_to>/Makefile pi@[pi's ip]:<rpi_path_to>/tensorflow/tensorflow/lite/tools/make
+(rpi) $ cd <path_to>/tensorflow/tensorflow/lite/tools/make/target
+(rpi) $ mv rpi_makefile.inc rpi_makefile.inc.orig
+(host)$ scp <local_path_to>/rpi_makefile.inc pi@[pi's ip]:<rpi_path_to>/tensorflow/tensorflow/lite/tools/make/target
 
+# FTP/scp the updated  that builds the label_image example as well
+(host)$ scp <local_path_to>/Makefile pi@[pi's ip]:<rpi_path_to>/tensorflow/tensorflow/lite/tools/make
 # Increase the RPi swap size otherwise 'make' will fail 
 (rpi) $ sudo nano /etc/dphys-swapfile
 ...CONF_SWAPSIZE=100 --> CONF_SWAPSIZE=2048

--- a/tensorflow/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/tensorflow/lite/tools/make/Makefile
@@ -48,6 +48,7 @@ INCLUDES += -I/usr/local/include
 # overridden by the platform-specific settings in target makefiles.
 LIBS := \
 -lstdc++ \
+-latomic \
 -lpthread \
 -lm \
 -lz
@@ -109,22 +110,14 @@ tensorflow/lite/experimental/ruy/allocator.cc \
 tensorflow/lite/experimental/ruy/block_map.cc \
 tensorflow/lite/experimental/ruy/blocking_counter.cc \
 tensorflow/lite/experimental/ruy/context.cc \
-tensorflow/lite/experimental/ruy/detect_arm.cc \
-tensorflow/lite/experimental/ruy/have_built_path_for_avx2.cc \
-tensorflow/lite/experimental/ruy/have_built_path_for_avx512.cc \
-tensorflow/lite/experimental/ruy/kernel_arm32.cc \
-tensorflow/lite/experimental/ruy/kernel_arm64.cc \
-tensorflow/lite/experimental/ruy/kernel_avx2.cc \
-tensorflow/lite/experimental/ruy/kernel_avx512.cc \
-tensorflow/lite/experimental/ruy/pack_arm.cc \
-tensorflow/lite/experimental/ruy/pack_avx2.cc \
-tensorflow/lite/experimental/ruy/pack_avx512.cc \
+tensorflow/lite/experimental/ruy/kernel.cc \
+tensorflow/lite/experimental/ruy/pack.cc \
 tensorflow/lite/experimental/ruy/pmu.cc \
 tensorflow/lite/experimental/ruy/thread_pool.cc \
 tensorflow/lite/experimental/ruy/trace.cc \
 tensorflow/lite/experimental/ruy/trmul.cc \
-tensorflow/lite/experimental/ruy/tune.cc \
-tensorflow/lite/experimental/ruy/wait.cc
+tensorflow/lite/experimental/ruy/tune.cc
+
 ifneq ($(BUILD_TYPE),micro)
 CORE_CC_ALL_SRCS += \
 $(wildcard tensorflow/lite/kernels/*.cc) \

--- a/tensorflow/tensorflow/lite/tools/make/target/rpi_makefile.inc
+++ b/tensorflow/tensorflow/lite/tools/make/target/rpi_makefile.inc
@@ -1,0 +1,61 @@
+# Settings for Raspberry Pi.
+ifeq ($(TARGET),rpi)
+  # Default to the architecture used on the Pi Two/Three (ArmV7), but override this
+  # with TARGET_ARCH=armv6 to build for the Pi Zero or One.
+  TARGET_ARCH := armv7l
+  TARGET_TOOLCHAIN_PREFIX := arm-linux-gnueabihf-
+
+  ifeq ($(TARGET_ARCH), armv7l)
+    CXXFLAGS += \
+			-march=armv7-a \
+      -mfpu=neon-vfpv4 \
+      -funsafe-math-optimizations \
+      -ftree-vectorize \
+      -fPIC
+
+    CFLAGS += \
+      -march=armv7-a \
+      -mfpu=neon-vfpv4 \
+      -funsafe-math-optimizations \
+      -ftree-vectorize \
+      -fPIC
+
+    LDFLAGS := \
+      -Wl,--no-export-dynamic \
+      -Wl,--exclude-libs,ALL \
+      -Wl,--gc-sections \
+      -Wl,--as-needed
+  endif
+
+  # TODO(petewarden) In the future, we'll want to use OpenBLAS as a faster
+  # alternative to Eigen on non-NEON ARM hardware like armv6.
+  ifeq ($(TARGET_ARCH), armv6)
+    CXXFLAGS += \
+      -march=armv6 \
+      -mfpu=vfp \
+      -funsafe-math-optimizations \
+      -ftree-vectorize \
+      -fPIC
+
+    CFLAGS += \
+      -march=armv6 \
+      -mfpu=vfp \
+      -funsafe-math-optimizations \
+      -ftree-vectorize \
+      -fPIC
+
+    LDFLAGS := \
+      -Wl,--no-export-dynamic \
+      -Wl,--exclude-libs,ALL \
+      -Wl,--gc-sections \
+      -Wl,--as-needed
+  endif
+       
+  LIBS := \
+    -lstdc++ \
+    -latomic \
+    -lpthread \
+    -lm \
+    -ldl
+
+endif


### PR DESCRIPTION
Found and resolved two problems during my porting work.

* The v1.14.0 from official doesn't match file list in the Makefile

What in the code:
pi@raspberrypi:~/tensorflow-1.14.0/tensorflow/lite/experimental/ruy $ ls
allocator.cc         internal_matrix.h   spec.h
allocator.h          kernel.cc           test_fast.cc
allocator_test.cc    kernel.h            test.h
benchmark.cc         matrix.h            test_slow.cc
blocking_counter.cc  opt_set.h           test_special_specs.cc
blocking_counter.h   pack.cc             thread_pool.cc
block_map.cc         pack.h              thread_pool.h
block_map.h          path.h              time.h
BUILD                pmu.cc              trace.cc
check_macros.h       pmu.h               trace.h
common.h             prepack.h           trmul.cc
context.cc           README.md           trmul.h
context.h            ruy_advanced.h      tune.cc
detect_dotprod.cc    ruy.h               tune.h
detect_dotprod.h     ruy_test.bzl        tune_test.cc
dispatch.h           ruy_test_ext.bzl    tune_tool.cc
example_advanced.cc  ruy_visibility.bzl
example.cc           size_util.h

The makefile:
CORE_CC_ALL_SRCS := \
$(wildcard tensorflow/lite/*.cc) \
$(wildcard tensorflow/lite/*.c) \
$(wildcard tensorflow/lite/c/*.c) \
$(wildcard tensorflow/lite/core/*.cc) \
$(wildcard tensorflow/lite/core/api/*.cc) \
$(wildcard tensorflow/lite/experimental/resource_variable/*.cc) \
tensorflow/lite/experimental/ruy/allocator.cc \
tensorflow/lite/experimental/ruy/block_map.cc \
tensorflow/lite/experimental/ruy/blocking_counter.cc \
tensorflow/lite/experimental/ruy/context.cc \
tensorflow/lite/experimental/ruy/detect_arm.cc \
tensorflow/lite/experimental/ruy/have_built_path_for_avx2.cc \
tensorflow/lite/experimental/ruy/have_built_path_for_avx512.cc \
tensorflow/lite/experimental/ruy/kernel_arm32.cc \
tensorflow/lite/experimental/ruy/kernel_arm64.cc \
tensorflow/lite/experimental/ruy/kernel_avx2.cc \
tensorflow/lite/experimental/ruy/kernel_avx512.cc \
tensorflow/lite/experimental/ruy/pack_arm.cc \
tensorflow/lite/experimental/ruy/pack_avx2.cc \
tensorflow/lite/experimental/ruy/pack_avx512.cc \
tensorflow/lite/experimental/ruy/pmu.cc \
tensorflow/lite/experimental/ruy/thread_pool.cc \
tensorflow/lite/experimental/ruy/trace.cc \
tensorflow/lite/experimental/ruy/trmul.cc \
tensorflow/lite/experimental/ruy/tune.cc \
tensorflow/lite/experimental/ruy/wait.cc

need to update the makefile

* undefined reference to `__atomic_load_8' in link stage

need to add the `-latomic` link flag in the makefile.

TEST: raspberry pi zero w, Linux version 4.19.118+ (dom@buildbot) (gcc version 4.9.3 (crosstool-NG crosstool-ng-1.22.0-88-g8460611)) #1311 Mon Apr 27 14:16:15 BST 2020

Signed-off-by: lanyusea <lanyusea@gmail.com>